### PR TITLE
Fix broken Table#update_id method

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ RNDBModel.create_db = function(db){
      */
     me.update_id = function(id, replace_data, callback){
         ReactNativeStore.table(me.db_name).then(function(collection){
-            collection.update_id(id, replace_data, function(data){
+            collection.updateById(id, replace_data, function(data){
                 if(callback){
                     callback(data);
                 }


### PR DESCRIPTION
`Table#update_id` seemed to be pointing to an older `Collection#update_id` method instead of `Collection#updateById`.
